### PR TITLE
Remove go 1.3 and 1.4 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 
 go:
-    - 1.3
-    - 1.4
     - 1.5
     - 1.6
     - tip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cloud Auth Proxy
 
+[![Master Build Status](https://travis-ci.org/kgraney/cloud_auth_proxy.svg?branch=master)](https://travis-ci.org/kgraney/cloud_auth_proxy)
+
 A proxy for handling authentication and authorization of Public Cloud API
 requests.
 


### PR DESCRIPTION
We might need to support something older than 1.5, but hopefully we
don't.  We have dependencies that don't work for 1.4 or 1.3.
