### PR TITLE
Add primitive linting to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ go:
     - 1.5
     - 1.6
     - tip
+
+script:
+    - for i in $(find . -iname "*.go"); do gofmt -d $i; done 
+    - echo '! for i in $(find . -iname "*.go"); do gofmt -l $i; done | read' | bash

--- a/googleapis/action.go
+++ b/googleapis/action.go
@@ -22,5 +22,8 @@ func Main(c *cli.Context) {
 
 	http.HandleFunc("/discovery/", discoveryHandler)
 	http.HandleFunc("/", proxyHandler(BuildReverseProxy()))
-	log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%d", port), "/home/kevin/go/server.pem", "/home/kevin/go/server.key", nil))
+	log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%d", port),
+		"/home/kmg/server.pem",
+		"/home/kmg/server.key",
+		nil))
 }

--- a/googleapis/handlers.go
+++ b/googleapis/handlers.go
@@ -11,7 +11,8 @@ import (
 
 func BuildReverseProxy() *httputil.ReverseProxy {
 	// TODO: renew oauth2 tokens
-	data, err := ioutil.ReadFile("/home/kevin/Google Sandbox-42115b17cf96.json")
+	logger.Info("Constructing reverse proxy")
+	data, err := ioutil.ReadFile("/home/kmg/Google Sandbox-42115b17cf96.json")
 	if err != nil {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
Printing out of the diffs isn't working yet for some reason.  Linting relies on gofmt.
